### PR TITLE
lpcorpus: add key and fix Value.Equal

### DIFF
--- a/lpcorpus/corpus.go
+++ b/lpcorpus/corpus.go
@@ -20,14 +20,17 @@ import (
 )
 
 // ReadCorpusJSON reads the corpus.json file named by file.
-func ReadCorpusJSON(file string) (*Corpus, error) {
-	data, err := ioutil.ReadFile(file)
+func ReadCorpusJSON(corpusFile string) (*Corpus, error) {
+	data, err := ioutil.ReadFile(corpusFile)
 	if err != nil {
 		return nil, err
 	}
 	var r Corpus
 	if err := json.Unmarshal(data, &r); err != nil {
-		return nil, err
+		if terr, ok := err.(*json.UnmarshalTypeError); ok {
+			return nil, fmt.Errorf("unmarshal error at %s:#%d: %v", corpusFile, terr.Offset, err)
+		}
+		return nil, fmt.Errorf("unmarshal error at %s: %v", corpusFile, err)
 	}
 	return &r, nil
 }
@@ -160,6 +163,7 @@ func (o1 *EncodeOutput) Equal(o2 *EncodeOutput) bool {
 }
 
 type DecodeInput struct {
+	Key            string    `json:"key"`
 	Text           Bytes     `json:"text"`
 	DefaultTime    int64     `json:"defaultTime"`
 	Precision      Precision `json:"precision"`
@@ -167,6 +171,7 @@ type DecodeInput struct {
 }
 
 type EncodeInput struct {
+	Key            string    `json:"key"`
 	Point          *Point    `json:"point"`
 	Precision      Precision `json:"precision"`
 	Implementation string    `json:"implementation,omitempty"`

--- a/lpcorpus/value.go
+++ b/lpcorpus/value.go
@@ -42,7 +42,15 @@ func MustNewValue(x interface{}) Value {
 }
 
 func (v1 Value) Equal(v2 Value) bool {
-	return v1.Kind() == v2.Kind() && v1.number == v2.number && bytes.Equal(v1.bytes, v2.bytes)
+	k := v1.Kind()
+	if v2.Kind() != k {
+		return false
+	}
+	if k != Float {
+		return v1.number == v2.number && bytes.Equal(v1.bytes, v2.bytes)
+	}
+	// Floats can't be compared bitwise.
+	return v1.FloatV() == v2.FloatV()
 }
 
 func NewValue(x interface{}) (Value, bool) {


### PR DESCRIPTION
It's useful for clients to have the `Key` field so that they can
sort the items into a slice without defining a new type.

`Value.Equal` didn't work correctly for float types because it
was comparing bitwise.

Also give a better error message on JSON parse failure.